### PR TITLE
Add content-available flag for background fetching

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -2,14 +2,19 @@ package apns
 
 import (
 	"crypto/tls"
+    "fmt"
 	"log"
 	"net"
 	"time"
 )
 
 const (
-	PRODUCTION_GATEWAY = "gateway.push.apple.com:2195"
-	SANDBOX_GATEWAY    = "gateway.sandbox.push.apple.com:2195"
+	PRODUCTION_GATEWAY = "gateway.push.apple.com"
+	SANDBOX_GATEWAY    = "gateway.sandbox.push.apple.com"
+)
+
+const (
+    GATEWAY_PORT = 2195
 )
 
 var (
@@ -58,10 +63,11 @@ func storeAndConnect(production bool, keyPair tls.Certificate) error {
 		// Production Connections
 		productionConfig = &tls.Config{
 			Certificates: []tls.Certificate{keyPair},
+			ServerName: PRODUCTION_GATEWAY,
 		}
 
 		productionConnection = &gatewayConnection{
-			gateway: PRODUCTION_GATEWAY,
+			gateway: fmt.Sprintf("%v:%v",PRODUCTION_GATEWAY, GATEWAY_PORT),
 			config:  productionConfig,
 		}
 
@@ -72,10 +78,11 @@ func storeAndConnect(production bool, keyPair tls.Certificate) error {
 		// Sandbox Connections
 		sandboxConfig = &tls.Config{
 			Certificates: []tls.Certificate{keyPair},
+			ServerName: SANDBOX_GATEWAY,
 		}
 
 		sandboxConnection = &gatewayConnection{
-			gateway: SANDBOX_GATEWAY,
+			gateway: fmt.Sprintf("%v:%v",SANDBOX_GATEWAY, GATEWAY_PORT),
 			config:  sandboxConfig,
 		}
 

--- a/notification.go
+++ b/notification.go
@@ -59,6 +59,9 @@ type Notification struct {
 	// Sets whether this should be sent via a sandbox connection or a production connection.
 	// If you have not loaded the appropriate certificates, this will fail.
 	Sandbox bool
+    
+	// Indicates new content is available for Newstand and background content downloads
+	ContentAvailable bool
 
 	// Custom values your app can use to set context for the user interface.
 	// You should not include customer information or any sensitive data.
@@ -159,7 +162,11 @@ func (this *Notification) toPayload() (*map[string]interface{}, error) {
 	if this.Sound != "" {
 		aps["sound"] = this.Sound
 	}
-
+    
+	if this.ContentAvailable {
+		aps["content-available"] = 1
+	}
+    
 	// All standard dictionaries need to be wrapped in the "aps" namespace.
 	payload["aps"] = &aps
 


### PR DESCRIPTION
Simple patch to support sending content-available for Newsstand apps.
