### PR TITLE
Bump up payload limit to 2K

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	// The maximum size allowed for a notification payload is 256 bytes.
+	// The maximum size allowed for a notification payload is 2048 bytes.
 	// Any notifications larger than this limit are refused by Apple.
-	MAX_PAYLOAD_SIZE = 265
+	MAX_PAYLOAD_SIZE = 2048
 
 	// The highest notification identifier we can send. Since the identifier can
 	// only be 4 bytes long, this is the maximum value of a 32-bit unsigned integer.


### PR DESCRIPTION
As of iOS 8, 2K payloads are now supported

https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html#//apple_ref/doc/uid/TP40008194-CH100-SW1
